### PR TITLE
Add configurable issue fields to issue commands

### DIFF
--- a/api/api.mbt
+++ b/api/api.mbt
@@ -50,6 +50,53 @@ fn get_string(obj : @core.Any, key : String, default? : String = "") -> String {
 }
 
 ///|
+fn any_to_display_string(value : @core.Any) -> String {
+  if @core.is_nullish(value) {
+    ""
+  } else {
+    match @core.typeof_(value) {
+      "string" | "number" | "boolean" | "bigint" => value.to_string()
+      "object" =>
+        if @core.is_array(value) {
+          @core.array_from(value)
+          .map(any_to_display_string)
+          .filter(fn(item) { item.length() > 0 })
+          .join(", ")
+        } else {
+          match
+            (
+              get_string(value, "type"),
+              get_string(value, "displayName"),
+              get_string(value, "name"),
+              get_string(value, "value"),
+            ) {
+            ("doc", _, _, _) => extract_adf_text(value)
+            (_, display_name, _, _) if display_name.length() > 0 => display_name
+            (_, _, name, _) if name.length() > 0 => name
+            (_, _, _, field_value) if field_value.length() > 0 => field_value
+            _ => @core.json_stringify(value)
+          }
+        }
+      _ => value.to_string()
+    }
+  }
+}
+
+///|
+fn extract_custom_fields(fields : @core.Any) -> Map[String, String] {
+  @core.object_keys(fields)
+  .filter(fn(name) { name.has_prefix("customfield_") })
+  .fold(init={}, fn(acc, name) {
+    let value = any_to_display_string(fields._get(name))
+    if value.length() == 0 {
+      acc
+    } else {
+      acc..set(name, value)
+    }
+  })
+}
+
+///|
 fn parse_issue(data : @core.Any) -> @types.JiraIssue {
   let fields = data._get("fields")
   let description_obj = fields._get("description")
@@ -70,6 +117,7 @@ fn parse_issue(data : @core.Any) -> @types.JiraIssue {
     issue_type: get_string(fields._get("issuetype"), "name"),
     priority: get_string(fields._get("priority"), "name"),
     description,
+    custom_fields: extract_custom_fields(fields),
   }
 }
 
@@ -89,18 +137,56 @@ fn parse_project(data : @core.Any) -> @types.JiraProject {
 }
 
 ///|
+fn requested_api_fields(fields : Array[@types.IssueField]) -> Array[String] {
+  fields
+  .map(fn(field) { field.api_name() })
+  .filter(fn(name) { name != "key" })
+  .fold(init=[], fn(acc, name) {
+    if acc.contains(name) {
+      acc
+    } else {
+      [..acc, name]
+    }
+  })
+}
+
+///|
+fn build_search_body(
+  jql : String,
+  fields : Array[@types.IssueField],
+) -> @core.Any {
+  let requested_fields = requested_api_fields(fields)
+  @core.from_entries(
+    [
+      ("jql", @core.any(jql)),
+      ("maxResults", @core.any(20)),
+      ..if requested_fields.is_empty() {
+        []
+      } else {
+        [("fields", @core.any(requested_fields))]
+      },
+    ],
+  )
+}
+
+///|
+fn build_issue_path(key : String, fields : Array[@types.IssueField]) -> String {
+  let requested_fields = requested_api_fields(fields)
+  if requested_fields.is_empty() {
+    "/rest/api/3/issue/\{key}"
+  } else {
+    let encoded_fields = encode_uri_component(requested_fields.join(","))
+    "/rest/api/3/issue/\{key}?fields=\{encoded_fields}"
+  }
+}
+
+///|
 pub async fn list_issues(
   config : @types.JiraConfig,
   jql : String,
+  fields : Array[@types.IssueField],
 ) -> Array[@types.JiraIssue] {
-  let fields : @core.Any = @core.any([
-    "summary", "status", "assignee", "issuetype", "priority", "description",
-  ])
-  let body = @core.from_entries([
-    ("jql", @core.any(jql)),
-    ("maxResults", @core.any(20)),
-    ("fields", fields),
-  ])
+  let body = build_search_body(jql, fields)
   let data = api_request(config, "POST", "/rest/api/3/search/jql", body~)
   parse_issues(data)
 }
@@ -109,8 +195,9 @@ pub async fn list_issues(
 pub async fn get_issue(
   config : @types.JiraConfig,
   key : String,
+  fields : Array[@types.IssueField],
 ) -> @types.JiraIssue {
-  let data = api_request(config, "GET", "/rest/api/3/issue/\{key}")
+  let data = api_request(config, "GET", build_issue_path(key, fields))
   parse_issue(data)
 }
 

--- a/api/api_wbtest.mbt
+++ b/api/api_wbtest.mbt
@@ -47,6 +47,7 @@ test "parse_issue with all fields" {
         ("issuetype", @core.from_entries([("name", @core.any("Bug"))])),
         ("priority", @core.from_entries([("name", @core.any("High"))])),
         ("description", description),
+        ("customfield_12345", @core.any("Platform Team")),
       ]),
     ),
   ])
@@ -58,6 +59,7 @@ test "parse_issue with all fields" {
   assert_eq(issue.issue_type, "Bug")
   assert_eq(issue.priority, "High")
   assert_eq(issue.description, "Test description")
+  assert_eq(issue.custom_fields["customfield_12345"], "Platform Team")
 }
 
 ///|
@@ -79,6 +81,21 @@ test "parse_issue with null assignee and description" {
   let issue = parse_issue(data)
   assert_eq(issue.assignee, "Unassigned")
   assert_eq(issue.description, "")
+}
+
+///|
+test "any_to_display_string handles object and array custom field values" {
+  let value = any_to_display_string(
+    @core.from_entries([("displayName", @core.any("Platform Team"))]),
+  )
+  let array_value = any_to_display_string(
+    @core.any([
+      @core.from_entries([("name", @core.any("Backend"))]),
+      @core.from_entries([("value", @core.any("Urgent"))]),
+    ]),
+  )
+  assert_eq(value, "Platform Team")
+  assert_eq(array_value, "Backend, Urgent")
 }
 
 ///|
@@ -127,6 +144,52 @@ test "parse_project" {
   assert_eq(project.key, "PROJ")
   assert_eq(project.name, "My Project")
   assert_eq(project.project_type, "software")
+}
+
+///|
+test "requested_api_fields excludes key and dedups aliases" {
+  inspect(
+    requested_api_fields([
+      @types.Key,
+      @types.Summary,
+      @types.IssueType,
+      @types.IssueType,
+      @types.Custom("customfield_12345"),
+    ]),
+    content="[\"summary\", \"issuetype\", \"customfield_12345\"]",
+  )
+}
+
+///|
+test "build_search_body includes requested fields" {
+  inspect(
+    @core.json_stringify_pretty(
+      build_search_body("project = TEST", [
+        @types.Key,
+        @types.Summary,
+        @types.Assignee,
+      ]),
+      2,
+    ),
+    content=(
+      #|{
+      #|  "jql": "project = TEST",
+      #|  "maxResults": 20,
+      #|  "fields": [
+      #|    "summary",
+      #|    "assignee"
+      #|  ]
+      #|}
+    ),
+  )
+}
+
+///|
+test "build_issue_path omits query when key only" {
+  inspect(
+    build_issue_path("TEST-1", [@types.Key]),
+    content="/rest/api/3/issue/TEST-1",
+  )
 }
 
 ///|

--- a/api/pkg.generated.mbti
+++ b/api/pkg.generated.mbti
@@ -12,9 +12,9 @@ pub async fn assign_issue(@types.JiraConfig, String, String) -> Unit
 
 pub async fn create_issue(@types.JiraConfig, String, String, String, String) -> String
 
-pub async fn get_issue(@types.JiraConfig, String) -> @types.JiraIssue
+pub async fn get_issue(@types.JiraConfig, String, Array[@types.IssueField]) -> @types.JiraIssue
 
-pub async fn list_issues(@types.JiraConfig, String) -> Array[@types.JiraIssue]
+pub async fn list_issues(@types.JiraConfig, String, Array[@types.IssueField]) -> Array[@types.JiraIssue]
 
 pub async fn list_projects(@types.JiraConfig) -> Array[@types.JiraProject]
 

--- a/formatter/formatter.mbt
+++ b/formatter/formatter.mbt
@@ -41,39 +41,42 @@ fn format_table(
 }
 
 ///|
-pub fn format_issue_list(issues : Array[@types.JiraIssue]) -> String {
+pub fn format_issue_list(
+  issues : Array[@types.JiraIssue],
+  fields : Array[@types.IssueField],
+) -> String {
   if issues.is_empty() {
     return "No issues found."
   }
-  let headers = ["KEY", "TYPE", "STATUS", "PRIORITY", "SUMMARY"]
-  let widths = [12, 12, 15, 10, 40]
+  let headers = fields.map(fn(field) { field.list_header() })
+  let widths = fields.map(fn(field) { field.table_width() })
   let rows = issues.map(fn(issue) {
-    [
-      issue.key,
-      truncate(issue.issue_type, 12),
-      truncate(issue.status, 15),
-      truncate(issue.priority, 10),
-      truncate(issue.summary, 40),
-    ]
+    fields.map(fn(field) {
+      truncate(issue.field_value(field), field.table_width())
+    })
   })
   format_table(headers, rows, widths)
 }
 
 ///|
-pub fn format_issue_detail(issue : @types.JiraIssue) -> String {
-  [
-    "Key:         \{issue.key}",
-    "Type:        \{issue.issue_type}",
-    "Status:      \{issue.status}",
-    "Priority:    \{issue.priority}",
-    "Assignee:    \{issue.assignee}",
-    "Summary:     \{issue.summary}",
-    ..if issue.description.length() > 0 {
-      ["Description: \{issue.description}"]
-    } else {
-      []
-    },
-  ].join("\n")
+fn format_detail_line(
+  issue : @types.JiraIssue,
+  field : @types.IssueField,
+) -> String? {
+  let value = issue.field_value(field)
+  let label = pad_right(field.detail_label() + ":", 12)
+  match (field, value) {
+    (@types.Description, "") => None
+    _ => Some("\{label} \{value}")
+  }
+}
+
+///|
+pub fn format_issue_detail(
+  issue : @types.JiraIssue,
+  fields : Array[@types.IssueField],
+) -> String {
+  fields.filter_map(fn(field) { format_detail_line(issue, field) }).join("\n")
 }
 
 ///|
@@ -94,9 +97,10 @@ pub fn format_usage() -> String {
   [
     "Jira CLI (MoonBit)", "", "Usage: jira <command> [options]", "", "Commands:",
     "  config      Set Jira configuration", "              --base-url <url> --email <email> --api-token <token>",
-    "  issues      List assigned issues (default JQL)", "              [--jql <jql>]",
-    "  issue       Get issue details", "              <key>", "  create      Create a new issue",
-    "              --project <key> --summary <text> [--type <type>] [--description <text>]",
+    "  issues      List assigned issues (default JQL)", "              [--jql <jql>] [--fields <field,...>]",
+    "  issue       Get issue details", "              <key> [--fields <field,...>]",
+    "              fields: key,summary,status,assignee,type,priority,description,customfield_<id>",
+    "  create      Create a new issue", "              --project <key> --summary <text> [--type <type>] [--description <text>]",
     "  transition  Transition issue status", "              --key <key> --status <status>",
     "  comment     Add comment to issue", "              --key <key> --text <text>",
     "  assign      Assign issue to user", "              --key <key> --email <email>",

--- a/formatter/formatter_wbtest.mbt
+++ b/formatter/formatter_wbtest.mbt
@@ -35,7 +35,10 @@ test "truncate: unicode safe" {
 
 ///|
 test "format_issue_list: empty" {
-  inspect(format_issue_list([]), content="No issues found.")
+  inspect(
+    format_issue_list([], @types.default_list_issue_fields()),
+    content="No issues found.",
+  )
 }
 
 ///|
@@ -49,10 +52,11 @@ test "format_issue_list: single issue" {
       issue_type: "Bug",
       priority: "High",
       description: "",
+      custom_fields: {},
     },
   ]
   inspect(
-    format_issue_list(issues),
+    format_issue_list(issues, @types.default_list_issue_fields()),
     content=(
       #|KEY           TYPE          STATUS           PRIORITY    SUMMARY                                 
       #|------------  ------------  ---------------  ----------  ----------------------------------------
@@ -71,9 +75,10 @@ test "format_issue_detail" {
     issue_type: "Bug",
     priority: "High",
     description: "Some description",
+    custom_fields: {},
   }
   inspect(
-    format_issue_detail(issue),
+    format_issue_detail(issue, @types.default_detail_issue_fields()),
     content=(
       #|Key:         PROJ-1
       #|Type:        Bug
@@ -82,6 +87,51 @@ test "format_issue_detail" {
       #|Assignee:    Alice
       #|Summary:     Fix bug
       #|Description: Some description
+    ),
+  )
+}
+
+///|
+test "format_issue_list: custom fields" {
+  let issues : Array[@types.JiraIssue] = [
+    {
+      key: "PROJ-1",
+      summary: "Fix bug",
+      status: "Open",
+      assignee: "Alice",
+      issue_type: "Bug",
+      priority: "High",
+      description: "",
+      custom_fields: {},
+    },
+  ]
+  inspect(
+    format_issue_list(issues, [@types.Key, @types.Assignee, @types.Summary]),
+    content=(
+      #|KEY           ASSIGNEE              SUMMARY                                 
+      #|------------  --------------------  ----------------------------------------
+      #|PROJ-1        Alice                 Fix bug                                 
+    ),
+  )
+}
+
+///|
+test "format_issue_detail: custom field" {
+  let issue : @types.JiraIssue = {
+    key: "PROJ-1",
+    summary: "Fix bug",
+    status: "Open",
+    assignee: "Alice",
+    issue_type: "Bug",
+    priority: "High",
+    description: "",
+    custom_fields: { "customfield_10001": "Platform Team" },
+  }
+  inspect(
+    format_issue_detail(issue, [@types.Key, @types.Custom("customfield_10001")]),
+    content=(
+      #|Key:         PROJ-1
+      #|customfield_10001: Platform Team
     ),
   )
 }

--- a/formatter/pkg.generated.mbti
+++ b/formatter/pkg.generated.mbti
@@ -6,9 +6,9 @@ import {
 }
 
 // Values
-pub fn format_issue_detail(@types.JiraIssue) -> String
+pub fn format_issue_detail(@types.JiraIssue, Array[@types.IssueField]) -> String
 
-pub fn format_issue_list(Array[@types.JiraIssue]) -> String
+pub fn format_issue_list(Array[@types.JiraIssue], Array[@types.IssueField]) -> String
 
 pub fn format_projects(Array[@types.JiraProject]) -> String
 

--- a/jira_cli_mbt.mbt
+++ b/jira_cli_mbt.mbt
@@ -12,13 +12,19 @@ pub async fn execute(cmd : Result[@types.Command, String]) -> String {
       @config.save_config({ base_url, email, api_token })
       "Configuration saved to ~/.config/jira_cli_mbt/config.json"
     }
-    Ok(@types.ListIssues(jql~)) => {
+    Ok(@types.ListIssues(jql~, fields~)) => {
       let config = @config.load_config()
-      @formatter.format_issue_list(@api.list_issues(config, jql))
+      @formatter.format_issue_list(
+        @api.list_issues(config, jql, fields),
+        fields,
+      )
     }
-    Ok(@types.GetIssue(key~)) => {
+    Ok(@types.GetIssue(key~, fields~)) => {
       let config = @config.load_config()
-      @formatter.format_issue_detail(@api.get_issue(config, key))
+      @formatter.format_issue_detail(
+        @api.get_issue(config, key, fields),
+        fields,
+      )
     }
     Ok(@types.CreateIssue(project~, summary~, issue_type~, description~)) => {
       let config = @config.load_config()
@@ -44,7 +50,11 @@ pub async fn execute(cmd : Result[@types.Command, String]) -> String {
     }
     Ok(@types.Search(jql~)) => {
       let config = @config.load_config()
-      @formatter.format_issue_list(@api.list_issues(config, jql))
+      let fields = @types.default_list_issue_fields()
+      @formatter.format_issue_list(
+        @api.list_issues(config, jql, fields),
+        fields,
+      )
     }
     Ok(@types.ListProjects) => {
       let config = @config.load_config()

--- a/parser/parser.mbt
+++ b/parser/parser.mbt
@@ -7,7 +7,7 @@ pub fn parse_args(args : ArrayView[String]) -> Result[@types.Command, String] {
     ["help" | "--help" | "-h", ..] => Ok(@types.Help)
     ["config", .. rest] => parse_config(rest)
     ["issues", .. rest] => parse_issues_cmd(rest)
-    ["issue", key, ..] => Ok(@types.GetIssue(key~))
+    ["issue", key, .. rest] => parse_issue_cmd(key, rest)
     ["issue", ..] => Err("Usage: issue <key>")
     ["create", .. rest] => parse_create(rest)
     ["transition", .. rest] => parse_transition(rest)
@@ -45,7 +45,13 @@ let config_flags : Map[String, String] = {
 }
 
 ///|
-let issues_flags : Map[String, String] = { "--jql": "jql" }
+let issues_flags : Map[String, String] = {
+  "--jql": "jql",
+  "--fields": "fields",
+}
+
+///|
+let issue_flags : Map[String, String] = { "--fields": "fields" }
 
 ///|
 let create_flags : Map[String, String] = {
@@ -108,12 +114,72 @@ fn parse_config(args : ArrayView[String]) -> Result[@types.Command, String] {
 }
 
 ///|
+fn parse_issue_fields(
+  value : String,
+) -> Result[Array[@types.IssueField], String] {
+  let names = value
+    .split(",")
+    .map(fn(name) { name.trim().to_string() })
+    .filter(fn(name) { name.length() > 0 })
+    .to_array()
+  guard not(names.is_empty()) else {
+    return Err("Field list must not be empty")
+  }
+  names.fold(init=Ok([]), fn(acc, name) {
+    match (acc, @types.parse_issue_field(name)) {
+      (Err(message), _) => Err(message)
+      (_, Err(message)) => Err(message)
+      (Ok(fields), Ok(field)) =>
+        Ok(if fields.contains(field) { fields } else { [..fields, field] })
+    }
+  })
+}
+
+///|
+fn resolve_issue_fields(
+  value : String?,
+  default_fields : Array[@types.IssueField],
+) -> Result[Array[@types.IssueField], String] {
+  match value {
+    Some(fields) => parse_issue_fields(fields)
+    None => Ok(default_fields)
+  }
+}
+
+///|
 fn parse_issues_cmd(args : ArrayView[String]) -> Result[@types.Command, String] {
   match parse_flags(args, issues_flags, {}) {
-    Ok(flags) => {
-      let jql = flags.get("jql").unwrap_or(default_jql)
-      Ok(@types.ListIssues(jql~))
-    }
+    Ok(flags) =>
+      match
+        resolve_issue_fields(
+          flags.get("fields"),
+          @types.default_list_issue_fields(),
+        ) {
+        Ok(fields) => {
+          let jql = flags.get("jql").unwrap_or(default_jql)
+          Ok(@types.ListIssues(jql~, fields~))
+        }
+        Err(message) => Err(message)
+      }
+    Err(message) => Err(message)
+  }
+}
+
+///|
+fn parse_issue_cmd(
+  key : String,
+  args : ArrayView[String],
+) -> Result[@types.Command, String] {
+  match parse_flags(args, issue_flags, {}) {
+    Ok(flags) =>
+      match
+        resolve_issue_fields(
+          flags.get("fields"),
+          @types.default_detail_issue_fields(),
+        ) {
+        Ok(fields) => Ok(@types.GetIssue(key~, fields~))
+        Err(message) => Err(message)
+      }
     Err(message) => Err(message)
   }
 }

--- a/parser/parser_test.mbt
+++ b/parser/parser_test.mbt
@@ -17,7 +17,7 @@ test "parse_args: empty args shows help" {
 test "parse_args: list issues with default jql" {
   inspect(
     @parser.parse_args(["issues"][:]),
-    content="Ok(ListIssues(jql=\"assignee = currentUser() ORDER BY updated DESC\"))",
+    content="Ok(ListIssues(jql=\"assignee = currentUser() ORDER BY updated DESC\", fields=[Key, IssueType, Status, Priority, Summary]))",
   )
 }
 
@@ -25,7 +25,31 @@ test "parse_args: list issues with default jql" {
 test "parse_args: list issues with custom jql" {
   inspect(
     @parser.parse_args(["issues", "--jql", "project = TEST"][:]),
-    content="Ok(ListIssues(jql=\"project = TEST\"))",
+    content="Ok(ListIssues(jql=\"project = TEST\", fields=[Key, IssueType, Status, Priority, Summary]))",
+  )
+}
+
+///|
+test "parse_args: list issues with custom fields" {
+  inspect(
+    @parser.parse_args(["issues", "--fields", "key,assignee,summary"][:]),
+    content="Ok(ListIssues(jql=\"assignee = currentUser() ORDER BY updated DESC\", fields=[Key, Assignee, Summary]))",
+  )
+}
+
+///|
+test "parse_args: list issues with custom jira field" {
+  inspect(
+    @parser.parse_args(["issues", "--fields", "key,customfield_12345"][:]),
+    content="Ok(ListIssues(jql=\"assignee = currentUser() ORDER BY updated DESC\", fields=[Key, Custom(\"customfield_12345\")]))",
+  )
+}
+
+///|
+test "parse_args: list issues rejects unknown field" {
+  inspect(
+    @parser.parse_args(["issues", "--fields", "key,unknown"][:]),
+    content="Err(\"Unsupported issue field: unknown\")",
   )
 }
 
@@ -33,7 +57,17 @@ test "parse_args: list issues with custom jql" {
 test "parse_args: get issue" {
   inspect(
     @parser.parse_args(["issue", "PROJ-123"][:]),
-    content="Ok(GetIssue(key=\"PROJ-123\"))",
+    content="Ok(GetIssue(key=\"PROJ-123\", fields=[Key, IssueType, Status, Priority, Assignee, Summary, Description]))",
+  )
+}
+
+///|
+test "parse_args: get issue with custom fields" {
+  inspect(
+    @parser.parse_args(
+      ["issue", "PROJ-123", "--fields", "summary, type, summary"][:],
+    ),
+    content="Ok(GetIssue(key=\"PROJ-123\", fields=[Summary, IssueType]))",
   )
 }
 

--- a/parser/parser_wbtest.mbt
+++ b/parser/parser_wbtest.mbt
@@ -36,3 +36,27 @@ test "parse_flags: reject globally known but disallowed flag" {
     content="Err(\"Unknown flag or unexpected argument: --email\")",
   )
 }
+
+///|
+test "parse_issue_fields: trims aliases and dedups" {
+  inspect(
+    parse_issue_fields(" summary, type ,summary "),
+    content="Ok([Summary, IssueType])",
+  )
+}
+
+///|
+test "parse_issue_fields: accepts custom jira fields" {
+  inspect(
+    parse_issue_fields("customfield_12345, customfield_12345"),
+    content="Ok([Custom(\"customfield_12345\")])",
+  )
+}
+
+///|
+test "parse_issue_fields: empty list" {
+  inspect(
+    parse_issue_fields(" , "),
+    content="Err(\"Field list must not be empty\")",
+  )
+}

--- a/types/pkg.generated.mbti
+++ b/types/pkg.generated.mbti
@@ -6,14 +6,19 @@ import {
 }
 
 // Values
+pub fn default_detail_issue_fields() -> Array[IssueField]
+
+pub fn default_list_issue_fields() -> Array[IssueField]
+
+pub fn parse_issue_field(String) -> Result[IssueField, String]
 
 // Errors
 
 // Types and methods
 pub(all) enum Command {
   Config(base_url~ : String, email~ : String, api_token~ : String)
-  ListIssues(jql~ : String)
-  GetIssue(key~ : String)
+  ListIssues(jql~ : String, fields~ : Array[IssueField])
+  GetIssue(key~ : String, fields~ : Array[IssueField])
   CreateIssue(project~ : String, summary~ : String, issue_type~ : String, description~ : String)
   Transition(key~ : String, status~ : String)
   Comment(key~ : String, text~ : String)
@@ -23,6 +28,23 @@ pub(all) enum Command {
   Help
 }
 pub impl Show for Command
+
+pub(all) enum IssueField {
+  Key
+  Summary
+  Status
+  Assignee
+  IssueType
+  Priority
+  Description
+  Custom(String)
+}
+pub fn IssueField::api_name(Self) -> String
+pub fn IssueField::detail_label(Self) -> String
+pub fn IssueField::list_header(Self) -> String
+pub fn IssueField::table_width(Self) -> Int
+pub impl Eq for IssueField
+pub impl Show for IssueField
 
 pub(all) struct JiraConfig {
   base_url : String
@@ -41,7 +63,9 @@ pub(all) struct JiraIssue {
   issue_type : String
   priority : String
   description : String
+  custom_fields : Map[String, String]
 }
+pub fn JiraIssue::field_value(Self, IssueField) -> String
 pub impl Show for JiraIssue
 
 pub(all) struct JiraProject {

--- a/types/types.mbt
+++ b/types/types.mbt
@@ -6,6 +6,91 @@ pub(all) struct JiraConfig {
 } derive(Show, ToJson, FromJson)
 
 ///|
+pub(all) enum IssueField {
+  Key
+  Summary
+  Status
+  Assignee
+  IssueType
+  Priority
+  Description
+  Custom(String)
+} derive(Show, Eq)
+
+///|
+pub fn parse_issue_field(name : String) -> Result[IssueField, String] {
+  let normalized = name.trim().to_string().to_lower()
+  match normalized {
+    "key" => Ok(Key)
+    "summary" => Ok(Summary)
+    "status" => Ok(Status)
+    "assignee" => Ok(Assignee)
+    "type" | "issue_type" | "issuetype" => Ok(IssueType)
+    "priority" => Ok(Priority)
+    "description" => Ok(Description)
+    "" => Err("Field name must not be empty")
+    _ if normalized.has_prefix("customfield_") => Ok(Custom(normalized))
+    other => Err("Unsupported issue field: \{other}")
+  }
+}
+
+///|
+pub fn IssueField::api_name(self : IssueField) -> String {
+  match self {
+    Key => "key"
+    Summary => "summary"
+    Status => "status"
+    Assignee => "assignee"
+    IssueType => "issuetype"
+    Priority => "priority"
+    Description => "description"
+    Custom(name) => name
+  }
+}
+
+///|
+pub fn IssueField::list_header(self : IssueField) -> String {
+  match self {
+    Key => "KEY"
+    Summary => "SUMMARY"
+    Status => "STATUS"
+    Assignee => "ASSIGNEE"
+    IssueType => "TYPE"
+    Priority => "PRIORITY"
+    Description => "DESCRIPTION"
+    Custom(name) => name
+  }
+}
+
+///|
+pub fn IssueField::detail_label(self : IssueField) -> String {
+  match self {
+    Key => "Key"
+    Summary => "Summary"
+    Status => "Status"
+    Assignee => "Assignee"
+    IssueType => "Type"
+    Priority => "Priority"
+    Description => "Description"
+    Custom(name) => name
+  }
+}
+
+///|
+pub fn IssueField::table_width(self : IssueField) -> Int {
+  match self {
+    Key => 12
+    Summary => 40
+    Status => 15
+    Assignee => 20
+    IssueType => 12
+    Priority => 10
+    Description => 40
+    Custom(name) => if name.length() > 20 { name.length() } else { 20 }
+  }
+}
+
+///|
 pub(all) struct JiraIssue {
   key : String
   summary : String
@@ -14,7 +99,22 @@ pub(all) struct JiraIssue {
   issue_type : String
   priority : String
   description : String
+  custom_fields : Map[String, String]
 } derive(Show)
+
+///|
+pub fn JiraIssue::field_value(self : JiraIssue, field : IssueField) -> String {
+  match field {
+    Key => self.key
+    Summary => self.summary
+    Status => self.status
+    Assignee => self.assignee
+    IssueType => self.issue_type
+    Priority => self.priority
+    Description => self.description
+    Custom(name) => self.custom_fields.get(name).unwrap_or("")
+  }
+}
 
 ///|
 pub(all) struct JiraProject {
@@ -24,10 +124,20 @@ pub(all) struct JiraProject {
 } derive(Show)
 
 ///|
+pub fn default_list_issue_fields() -> Array[IssueField] {
+  [Key, IssueType, Status, Priority, Summary]
+}
+
+///|
+pub fn default_detail_issue_fields() -> Array[IssueField] {
+  [Key, IssueType, Status, Priority, Assignee, Summary, Description]
+}
+
+///|
 pub(all) enum Command {
   Config(base_url~ : String, email~ : String, api_token~ : String)
-  ListIssues(jql~ : String)
-  GetIssue(key~ : String)
+  ListIssues(jql~ : String, fields~ : Array[IssueField])
+  GetIssue(key~ : String, fields~ : Array[IssueField])
   CreateIssue(
     project~ : String,
     summary~ : String,

--- a/types/types_test.mbt
+++ b/types/types_test.mbt
@@ -1,0 +1,41 @@
+///|
+test "parse_issue_field supports aliases" {
+  inspect(@types.parse_issue_field("type"), content="Ok(IssueType)")
+  inspect(@types.parse_issue_field("issuetype"), content="Ok(IssueType)")
+  inspect(
+    @types.parse_issue_field("customfield_12345"),
+    content="Ok(Custom(\"customfield_12345\"))",
+  )
+}
+
+///|
+test "default issue field sets stay stable" {
+  inspect(
+    @types.default_list_issue_fields(),
+    content="[Key, IssueType, Status, Priority, Summary]",
+  )
+  inspect(
+    @types.default_detail_issue_fields(),
+    content="[Key, IssueType, Status, Priority, Assignee, Summary, Description]",
+  )
+}
+
+///|
+test "jira issue field_value reads requested field" {
+  let issue : @types.JiraIssue = {
+    key: "PROJ-1",
+    summary: "Fix bug",
+    status: "Open",
+    assignee: "Alice",
+    issue_type: "Bug",
+    priority: "High",
+    description: "Details",
+    custom_fields: { "customfield_12345": "Platform Team" },
+  }
+  assert_eq(issue.field_value(@types.Assignee), "Alice")
+  assert_eq(issue.field_value(@types.Description), "Details")
+  assert_eq(
+    issue.field_value(@types.Custom("customfield_12345")),
+    "Platform Team",
+  )
+}


### PR DESCRIPTION
## Summary
- add field selection support to `issues` and `issue`
- keep the field handling declarative via `IssueField` definitions shared by parser, API, and formatter
- support both built-in fields and generic custom field keys without exposing project-specific field details in this PR

## Testing
- moon check --target js
- moon test --target js
- moon fmt
- moon info --target js

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--fields` option to customize displayed fields for both list and detail views
  * Enabled support for custom Jira fields (e.g., customfield_*) in issue details
  * Users can now select from: key, summary, status, assignee, type, priority, description, and custom fields
  * Configurable output based on field selection for improved flexibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->