### PR TITLE
test: parse_field のユニットテスト追加

### DIFF
--- a/api/api_wbtest.mbt
+++ b/api/api_wbtest.mbt
@@ -147,6 +147,50 @@ test "parse_project" {
 }
 
 ///|
+test "parse_field with schema" {
+  let data = @core.from_entries([
+    ("id", @core.any("customfield_10001")),
+    ("name", @core.any("Severity")),
+    ("custom", @core.any(true)),
+    (
+      "schema",
+      @core.from_entries([
+        ("type", @core.any("option")),
+        (
+          "custom",
+          @core.any("com.atlassian.jira.plugin.system.customfieldtypes:select"),
+        ),
+      ]),
+    ),
+  ])
+  let field = parse_field(data)
+  assert_eq(field.id, "customfield_10001")
+  assert_eq(field.name, "Severity")
+  assert_true(field.custom)
+  assert_eq(field.schema_type, "option")
+  assert_eq(
+    field.schema_custom,
+    "com.atlassian.jira.plugin.system.customfieldtypes:select",
+  )
+}
+
+///|
+test "parse_field with nullish schema" {
+  let data = @core.from_entries([
+    ("id", @core.any("customfield_10002")),
+    ("name", @core.any("Notes")),
+    ("custom", @core.any(true)),
+    ("schema", js_null()),
+  ])
+  let field = parse_field(data)
+  assert_eq(field.id, "customfield_10002")
+  assert_eq(field.name, "Notes")
+  assert_true(field.custom)
+  assert_eq(field.schema_type, "")
+  assert_eq(field.schema_custom, "")
+}
+
+///|
 test "requested_api_fields excludes key and dedups aliases" {
   inspect(
     requested_api_fields([


### PR DESCRIPTION
## Summary
- `parse_field` の whitebox テストを追加
- schema ありケースで `schema_type` と `schema_custom` を検証
- schema nullish ケースで空文字列フォールバックを検証

## Testing
- `moon check --target js`
- `moon test --target js api/api_wbtest.mbt`
- `moon test --target js`
- `moon info --target js`
- `moon fmt`
- `moon test --target js api/api_wbtest.mbt`

Closes #15


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for field parsing to validate schema information extraction and handle nullish schema scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->