### PR TITLE
fix: fields 空の issue type リスト時の案内を改善

### DIFF
--- a/jira_cli_mbt.mbt
+++ b/jira_cli_mbt.mbt
@@ -4,6 +4,19 @@ pub fn parse_args(args : ArrayView[String]) -> Result[@types.Command, String] {
 }
 
 ///|
+fn issue_type_selection_message(
+  project : String,
+  types : Array[(String, String)],
+) -> String {
+  if types.is_empty() {
+    "No issue types found for project '\{project}'. Verify the project key is correct."
+  } else {
+    let type_list = types.map(fn(t) { "  - " + t.1 }).join("\n")
+    "Please specify --type. Available issue types for \{project}:\n" + type_list
+  }
+}
+
+///|
 pub async fn execute(cmd : Result[@types.Command, String]) -> String {
   match cmd {
     Err(msg) => @formatter.format_usage() + "\n\nError: " + msg
@@ -102,9 +115,7 @@ pub async fn execute(cmd : Result[@types.Command, String]) -> String {
       let config = @config.load_config()
       if project.length() > 0 && issue_type.length() == 0 {
         let types = @api.list_issue_types(config, project)
-        let type_list = types.map(fn(t) { "  - " + t.1 }).join("\n")
-        "Please specify --type. Available issue types for \{project}:\n" +
-        type_list
+        issue_type_selection_message(project, types)
       } else {
         @formatter.format_field_detail(
           @api.get_field_detail(config, field_id, project, issue_type),

--- a/jira_cli_mbt_wbtest.mbt
+++ b/jira_cli_mbt_wbtest.mbt
@@ -1,0 +1,15 @@
+///|
+test "issue_type_selection_message: empty issue types" {
+  assert_eq(
+    issue_type_selection_message("AJ", []),
+    "No issue types found for project 'AJ'. Verify the project key is correct.",
+  )
+}
+
+///|
+test "issue_type_selection_message: available issue types" {
+  assert_eq(
+    issue_type_selection_message("AJ", [("1", "Task"), ("2", "Bug")]),
+    "Please specify --type. Available issue types for AJ:\n  - Task\n  - Bug",
+  )
+}


### PR DESCRIPTION
## Summary
- `GetField` の issue type 案内文を private helper に切り出し
- `list_issue_types` が空リストを返したときに project key の確認を促す文言を表示
- root package の whitebox テストで空リスト時と通常時の案内文を追加

## Testing
- `moon check --target js`
- `moon test --target js jira_cli_mbt_wbtest.mbt`
- `moon test --target js`
- `moon info --target js`
- `moon fmt`
- `moon test --target js jira_cli_mbt_wbtest.mbt`

Closes #14


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error messaging when issue types cannot be found for a project, helping users verify their project key.
  * Enhanced user guidance when specifying issue types by providing clearer prompts with available options listed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->