### PR TITLE
Add --parent support to issue create/update

### DIFF
--- a/README.mbt.md
+++ b/README.mbt.md
@@ -212,13 +212,14 @@ Legacy alias: `jira-cli issue PROJ-123`
 Create a new issue.
 
 ```sh
-jira-cli issue create --project <key> --summary <text> [--type <type>] [--description <text>] [--set <field=value>]... [--set-json <json-object>] [--dry-run] [--format <table|tsv|json>]
+jira-cli issue create --project <key> --summary <text> [--type <type>] [--description <text>] [--parent <key|id>] [--set <field=value>]... [--set-json <json-object>] [--dry-run] [--format <table|tsv|json>]
 ```
 
 - `--project` — Project key (required)
 - `--summary` — Issue summary (required)
 - `--type` — Issue type (default: `Task`)
 - `--description` — Issue description
+- `--parent` — Parent issue key or numeric issue ID
 - `--set` — Convenience shortcut for simple custom field values (repeatable, format: `customfield_xxxxx=value`)
 - `--set-json` — Structured custom field payload as a JSON object keyed by `customfield_*`
 - `--dry-run` — Preview the request without calling Jira
@@ -228,11 +229,12 @@ Example:
 
 ```sh
 jira-cli issue create --project MYPROJ --summary "Fix login bug" --type Bug --description "Login fails on Safari"
+jira-cli issue create --project MYPROJ --summary "Implement child task" --parent EPIC-123
 jira-cli issue create --project MYPROJ --summary "Fix login bug" --dry-run --format json
 jira-cli issue create --project MYPROJ --summary "Provision access" --set-json '{"customfield_10001":{"id":"10401"},"customfield_10002":"Platform Team"}'
 ```
 
-Prefer `--set-json` for explicit typed values such as option IDs, arrays, or nested objects. `--set` remains available as a convenience shortcut, and purely numeric `--set` values still map to `{ "id": "<value>" }` for backward compatibility.
+Use `--parent` for Jira's standard parent field. Prefer `--set-json` for explicit typed values such as option IDs, arrays, or nested objects. `--set` remains available as a convenience shortcut, and purely numeric `--set` values still map to `{ "id": "<value>" }` for backward compatibility.
 
 Legacy alias: `jira-cli create`
 
@@ -241,7 +243,7 @@ Legacy alias: `jira-cli create`
 Update an existing issue.
 
 ```sh
-jira-cli issue update <key> [--summary <text>] [--description <text>] [--priority <name>] [--type <name>] [--labels <label1,label2>] [--assignee <email>] [--set <field=value>]... [--set-json <json-object>] [--dry-run] [--format <table|tsv|json>]
+jira-cli issue update <key> [--summary <text>] [--description <text>] [--priority <name>] [--type <name>] [--labels <label1,label2>] [--parent <key|id>] [--assignee <email>] [--set <field=value>]... [--set-json <json-object>] [--dry-run] [--format <table|tsv|json>]
 ```
 
 - `<key>` — Issue key (required)
@@ -250,6 +252,7 @@ jira-cli issue update <key> [--summary <text>] [--description <text>] [--priorit
 - `--priority` — Priority name
 - `--type` — Issue type name
 - `--labels` — Comma-separated labels
+- `--parent` — Parent issue key or numeric issue ID
 - `--assignee` — Assignee email
 - `--set` — Convenience shortcut for simple custom field values (repeatable, format: `customfield_xxxxx=value`)
 - `--set-json` — Structured custom field payload as a JSON object keyed by `customfield_*`
@@ -262,11 +265,12 @@ Example:
 
 ```sh
 jira-cli issue update PROJ-123 --priority High --labels "backend,urgent"
+jira-cli issue update PROJ-123 --parent EPIC-123
 jira-cli issue update PROJ-123 --summary "Refine rollout plan" --assignee user@example.com --dry-run --format json
 jira-cli issue update PROJ-123 --set-json '{"customfield_10001":{"id":"10401"},"customfield_10002":["Backend","Urgent"]}'
 ```
 
-`--set` and `--set-json` both require `customfield_*` keys. If the same key appears multiple times across either flag, the last value wins.
+Use `--parent` for Jira's standard parent field. `--set` and `--set-json` both require `customfield_*` keys. If the same key appears multiple times across either flag, the last value wins.
 
 Legacy alias: `jira-cli update`
 
@@ -445,6 +449,7 @@ The `--fields` flag accepts the following field names (case-insensitive):
 | `priority` | Priority level |
 | `type` | Issue type (aliases: `issue_type`, `issuetype`) |
 | `assignee` | Assigned user |
+| `parent` | Parent issue key or ID |
 | `description` | Issue description |
 | `customfield_*` | Any custom field by ID (e.g. `customfield_10001`) |
 

--- a/api/api.mbt
+++ b/api/api.mbt
@@ -145,10 +145,19 @@ fn extract_custom_fields(fields : @core.Any) -> Map[String, String] {
 fn parse_issue(data : @core.Any) -> @types.JiraIssue {
   let fields = data._get("fields")
   let description_obj = fields._get("description")
+  let parent_obj = fields._get("parent")
   let description = if @core.is_nullish(description_obj) {
     ""
   } else {
     extract_adf_text(description_obj)
+  }
+  let parent = {
+    let key = get_string(parent_obj, "key")
+    if key.length() > 0 {
+      key
+    } else {
+      get_string(parent_obj, "id")
+    }
   }
   {
     key: get_string(data, "key"),
@@ -159,6 +168,7 @@ fn parse_issue(data : @core.Any) -> @types.JiraIssue {
       "displayName",
       default="Unassigned",
     ),
+    parent,
     issue_type: get_string(fields._get("issuetype"), "name"),
     priority: get_string(fields._get("priority"), "name"),
     description,
@@ -532,17 +542,18 @@ pub async fn create_issue(
   summary : String,
   issue_type : String,
   description : String,
+  parent : String,
   custom_fields : Map[String, @types.CustomFieldInput],
 ) -> @types.MutationReport {
   let field_changes = create_issue_field_changes(
-    project, summary, issue_type, description, custom_fields,
+    project, summary, issue_type, description, parent, custom_fields,
   )
   let body = @core.from_entries([
     (
       "fields",
       @core.from_entries(
         create_issue_field_entries(
-          project, summary, issue_type, description, custom_fields,
+          project, summary, issue_type, description, parent, custom_fields,
         ),
       ),
     ),
@@ -560,14 +571,15 @@ pub async fn update_issue(
   priority~ : String,
   issue_type~ : String,
   labels~ : String,
+  parent~ : String,
   assignee~ : String,
   custom_fields~ : Map[String, @types.CustomFieldInput],
 ) -> @types.MutationReport {
   let field_changes = update_issue_field_changes(
-    summary, description, priority, issue_type, labels, assignee, custom_fields,
+    summary, description, priority, issue_type, labels, parent, assignee, custom_fields,
   )
   let field_entries = update_issue_field_entries(
-    summary, description, priority, issue_type, labels, custom_fields,
+    summary, description, priority, issue_type, labels, parent, custom_fields,
   )
   if not(field_entries.is_empty()) {
     let body = @core.from_entries([

--- a/api/api_wbtest.mbt
+++ b/api/api_wbtest.mbt
@@ -44,6 +44,7 @@ test "parse_issue with all fields" {
         ("summary", @core.any("Test summary")),
         ("status", @core.from_entries([("name", @core.any("In Progress"))])),
         ("assignee", @core.from_entries([("displayName", @core.any("Alice"))])),
+        ("parent", @core.from_entries([("key", @core.any("EPIC-1"))])),
         ("issuetype", @core.from_entries([("name", @core.any("Bug"))])),
         ("priority", @core.from_entries([("name", @core.any("High"))])),
         ("description", description),
@@ -56,6 +57,7 @@ test "parse_issue with all fields" {
   assert_eq(issue.summary, "Test summary")
   assert_eq(issue.status, "In Progress")
   assert_eq(issue.assignee, "Alice")
+  assert_eq(issue.parent, "EPIC-1")
   assert_eq(issue.issue_type, "Bug")
   assert_eq(issue.priority, "High")
   assert_eq(issue.description, "Test description")
@@ -196,11 +198,12 @@ test "requested_api_fields excludes key and dedups aliases" {
     requested_api_fields([
       @types.Key,
       @types.Summary,
+      @types.Parent,
       @types.IssueType,
       @types.IssueType,
       @types.Custom("customfield_12345"),
     ]),
-    content="[\"summary\", \"issuetype\", \"customfield_12345\"]",
+    content="[\"summary\", \"parent\", \"issuetype\", \"customfield_12345\"]",
   )
 }
 
@@ -257,17 +260,24 @@ test "issue_search_page_size keeps small single-page requests" {
 
 ///|
 test "preview_create_issue returns stable dry-run report" {
-  let report = preview_create_issue("APP", "Fix login bug", "Bug", "", {
-    "customfield_200": @types.custom_field_input_string("Zed"),
-    "customfield_100": @types.custom_field_input_string("Alpha"),
-  })
+  let report = preview_create_issue(
+    "APP",
+    "Fix login bug",
+    "Bug",
+    "",
+    "EPIC-1",
+    {
+      "customfield_200": @types.custom_field_input_string("Zed"),
+      "customfield_100": @types.custom_field_input_string("Alpha"),
+    },
+  )
   assert_eq(report.command, "issue create")
   assert_eq(report.status, @types.DryRun)
   assert_true(report.dry_run)
   assert_eq(report.project_key, "APP")
   assert_eq(
     report.field_changes.map(fn(change) { change.name }).join(","),
-    "project,summary,issue_type,customfield_100,customfield_200",
+    "project,summary,issue_type,parent,customfield_100,customfield_200",
   )
   assert_eq(report.operations.length(), 1)
   assert_eq(report.operations[0].status, @types.Planned)
@@ -282,6 +292,7 @@ test "preview_update_issue includes planned operations and normalized labels" {
     "High",
     "",
     "backend, urgent",
+    "EPIC-1",
     "user@example.com",
     { "customfield_10001": @types.custom_field_input_option_id("10401") },
   )
@@ -293,7 +304,7 @@ test "preview_update_issue includes planned operations and normalized labels" {
     report.field_changes
     .map(fn(change) { change.name + "=" + change.value })
     .join(","),
-    "summary=Refine rollout plan,priority=High,labels=backend,urgent,assignee=user@example.com,customfield_10001={\"id\":\"10401\"}",
+    "summary=Refine rollout plan,priority=High,labels=backend,urgent,parent=EPIC-1,assignee=user@example.com,customfield_10001={\"id\":\"10401\"}",
   )
   assert_eq(
     report.operations

--- a/api/mutations.mbt
+++ b/api/mutations.mbt
@@ -20,6 +20,29 @@ fn normalized_label_values(labels : String) -> Array[String] {
 }
 
 ///|
+fn is_numeric_issue_reference(value : String) -> Bool {
+  if value.length() == 0 {
+    return false
+  }
+  for i in 0..<value.length() {
+    let c = value[i].to_int().unsafe_to_char()
+    if c < '0' || c > '9' {
+      return false
+    }
+  }
+  true
+}
+
+///|
+fn parent_field_value(parent : String) -> @core.Any {
+  if is_numeric_issue_reference(parent) {
+    @core.from_entries([("id", @core.any(parent))])
+  } else {
+    @core.from_entries([("key", @core.any(parent))])
+  }
+}
+
+///|
 fn mutation_field_change(
   name : String,
   value : String,
@@ -42,6 +65,7 @@ fn create_issue_field_changes(
   summary : String,
   issue_type : String,
   description : String,
+  parent : String,
   custom_fields : Map[String, @types.CustomFieldInput],
 ) -> Array[@types.MutationFieldChange] {
   let changes : Array[@types.MutationFieldChange] = [
@@ -51,6 +75,9 @@ fn create_issue_field_changes(
   ]
   if description.length() > 0 {
     changes.push(mutation_field_change("description", description))
+  }
+  if parent.length() > 0 {
+    changes.push(mutation_field_change("parent", parent))
   }
   for entry in sorted_custom_field_entries(custom_fields) {
     changes.push(mutation_field_change(entry.0, entry.1.display_value()))
@@ -65,6 +92,7 @@ fn update_issue_field_changes(
   priority : String,
   issue_type : String,
   labels : String,
+  parent : String,
   assignee : String,
   custom_fields : Map[String, @types.CustomFieldInput],
 ) -> Array[@types.MutationFieldChange] {
@@ -85,6 +113,9 @@ fn update_issue_field_changes(
   if not(label_values.is_empty()) {
     changes.push(mutation_field_change("labels", label_values.join(",")))
   }
+  if parent.length() > 0 {
+    changes.push(mutation_field_change("parent", parent))
+  }
   if assignee.length() > 0 {
     changes.push(mutation_field_change("assignee", assignee))
   }
@@ -100,6 +131,7 @@ fn create_issue_field_entries(
   summary : String,
   issue_type : String,
   description : String,
+  parent : String,
   custom_fields : Map[String, @types.CustomFieldInput],
 ) -> Array[(String, @core.Any)] {
   [
@@ -108,6 +140,11 @@ fn create_issue_field_entries(
     ("issuetype", @core.from_entries([("name", @core.any(issue_type))])),
     ..if description.length() > 0 {
       [("description", build_adf_text(description))]
+    } else {
+      []
+    },
+    ..if parent.length() > 0 {
+      [("parent", parent_field_value(parent))]
     } else {
       []
     },
@@ -124,6 +161,7 @@ fn update_issue_field_entries(
   priority : String,
   issue_type : String,
   labels : String,
+  parent : String,
   custom_fields : Map[String, @types.CustomFieldInput],
 ) -> Array[(String, @core.Any)] {
   let field_entries : Array[(String, @core.Any)] = []
@@ -146,6 +184,9 @@ fn update_issue_field_entries(
   let label_values = normalized_label_values(labels)
   if not(label_values.is_empty()) {
     field_entries.push(("labels", @core.any(label_values)))
+  }
+  if parent.length() > 0 {
+    field_entries.push(("parent", parent_field_value(parent)))
   }
   for entry in sorted_custom_field_entries(custom_fields) {
     field_entries.push((entry.0, custom_field_value(entry.1)))
@@ -183,10 +224,11 @@ pub fn preview_create_issue(
   summary : String,
   issue_type : String,
   description : String,
+  parent : String,
   custom_fields : Map[String, @types.CustomFieldInput],
 ) -> @types.MutationReport {
   let field_changes = create_issue_field_changes(
-    project, summary, issue_type, description, custom_fields,
+    project, summary, issue_type, description, parent, custom_fields,
   )
   mutation_report(
     "issue create",
@@ -236,14 +278,15 @@ pub fn preview_update_issue(
   priority : String,
   issue_type : String,
   labels : String,
+  parent : String,
   assignee : String,
   custom_fields : Map[String, @types.CustomFieldInput],
 ) -> @types.MutationReport {
   let field_changes = update_issue_field_changes(
-    summary, description, priority, issue_type, labels, assignee, custom_fields,
+    summary, description, priority, issue_type, labels, parent, assignee, custom_fields,
   )
   let field_entries = update_issue_field_entries(
-    summary, description, priority, issue_type, labels, custom_fields,
+    summary, description, priority, issue_type, labels, parent, custom_fields,
   )
   let operations : Array[@types.MutationOperation] = []
   if not(field_entries.is_empty()) {

--- a/api/pkg.generated.mbti
+++ b/api/pkg.generated.mbti
@@ -10,7 +10,7 @@ pub async fn add_comment(@types.JiraConfig, String, String) -> Unit
 
 pub async fn assign_issue(@types.JiraConfig, String, String) -> Unit
 
-pub async fn create_issue(@types.JiraConfig, String, String, String, String, Map[String, @types.CustomFieldInput]) -> @types.MutationReport
+pub async fn create_issue(@types.JiraConfig, String, String, String, String, String, Map[String, @types.CustomFieldInput]) -> @types.MutationReport
 
 pub async fn get_field_detail(@types.JiraConfig, String, String, String) -> @types.JiraFieldDetail
 
@@ -24,13 +24,13 @@ pub async fn list_issues(@types.JiraConfig, String, Array[@types.IssueField], @t
 
 pub async fn list_projects(@types.JiraConfig, @types.PageRequest) -> @types.JiraProjectPage
 
-pub fn preview_create_issue(String, String, String, String, Map[String, @types.CustomFieldInput]) -> @types.MutationReport
+pub fn preview_create_issue(String, String, String, String, String, Map[String, @types.CustomFieldInput]) -> @types.MutationReport
 
-pub fn preview_update_issue(String, String, String, String, String, String, String, Map[String, @types.CustomFieldInput]) -> @types.MutationReport
+pub fn preview_update_issue(String, String, String, String, String, String, String, String, Map[String, @types.CustomFieldInput]) -> @types.MutationReport
 
 pub async fn transition_issue(@types.JiraConfig, String, String) -> Unit
 
-pub async fn update_issue(@types.JiraConfig, key~ : String, summary~ : String, description~ : String, priority~ : String, issue_type~ : String, labels~ : String, assignee~ : String, custom_fields~ : Map[String, @types.CustomFieldInput]) -> @types.MutationReport
+pub async fn update_issue(@types.JiraConfig, key~ : String, summary~ : String, description~ : String, priority~ : String, issue_type~ : String, labels~ : String, parent~ : String, assignee~ : String, custom_fields~ : Map[String, @types.CustomFieldInput]) -> @types.MutationReport
 
 // Errors
 pub suberror JiraApiError {

--- a/formatter/formatter.mbt
+++ b/formatter/formatter.mbt
@@ -114,6 +114,7 @@ fn issue_field_name(field : @types.IssueField) -> String {
     @types.Summary => "summary"
     @types.Status => "status"
     @types.Assignee => "assignee"
+    @types.Parent => "parent"
     @types.IssueType => "type"
     @types.Priority => "priority"
     @types.Description => "description"

--- a/formatter/formatter_wbtest.mbt
+++ b/formatter/formatter_wbtest.mbt
@@ -49,6 +49,7 @@ test "format_issue_list: single issue" {
       summary: "Fix bug",
       status: "Open",
       assignee: "Alice",
+      parent: "",
       issue_type: "Bug",
       priority: "High",
       description: "",
@@ -72,6 +73,7 @@ test "format_issue_detail" {
     summary: "Fix bug",
     status: "Open",
     assignee: "Alice",
+    parent: "",
     issue_type: "Bug",
     priority: "High",
     description: "Some description",
@@ -99,6 +101,7 @@ test "format_issue_list: custom fields" {
       summary: "Fix bug",
       status: "Open",
       assignee: "Alice",
+      parent: "",
       issue_type: "Bug",
       priority: "High",
       description: "",
@@ -122,6 +125,7 @@ test "format_issue_detail: custom field" {
     summary: "Fix bug",
     status: "Open",
     assignee: "Alice",
+    parent: "",
     issue_type: "Bug",
     priority: "High",
     description: "",
@@ -132,6 +136,28 @@ test "format_issue_detail: custom field" {
     content=(
       #|Key:         PROJ-1
       #|customfield_10001: Platform Team
+    ),
+  )
+}
+
+///|
+test "format_issue_detail: parent field" {
+  let issue : @types.JiraIssue = {
+    key: "PROJ-1",
+    summary: "Fix bug",
+    status: "Open",
+    assignee: "Alice",
+    parent: "EPIC-1",
+    issue_type: "Bug",
+    priority: "High",
+    description: "",
+    custom_fields: {},
+  }
+  inspect(
+    format_issue_detail(issue, [@types.Key, @types.Parent]),
+    content=(
+      #|Key:         PROJ-1
+      #|Parent:      EPIC-1
     ),
   )
 }
@@ -263,9 +289,9 @@ test "format_usage: shows installed binary names" {
       #|  issue get        Get issue details
       #|                   issue get <key> [--fields <field,...>] [--format <table|tsv|json>]
       #|  issue create     Create a new issue
-      #|                   issue create --project <key> --summary <text> [--type <type>] [--description <text>] [--set <field=value>]... [--set-json <json-object>] [--dry-run] [--format <table|tsv|json>]
+      #|                   issue create --project <key> --summary <text> [--type <type>] [--description <text>] [--parent <key|id>] [--set <field=value>]... [--set-json <json-object>] [--dry-run] [--format <table|tsv|json>]
       #|  issue update     Update an existing issue
-      #|                   issue update <key> [--summary <text>] [--description <text>] [--priority <name>] [--type <name>] [--labels <label1,label2>] [--assignee <email>] [--set <field=value>]... [--set-json <json-object>] [--dry-run] [--format <table|tsv|json>]
+      #|                   issue update <key> [--summary <text>] [--description <text>] [--priority <name>] [--type <name>] [--labels <label1,label2>] [--parent <key|id>] [--assignee <email>] [--set <field=value>]... [--set-json <json-object>] [--dry-run] [--format <table|tsv|json>]
       #|  issue transition Transition issue status
       #|                   issue transition --key <key> --status <status>
       #|  issue comment    Add comment to issue
@@ -349,7 +375,7 @@ test "format_command_help: issue get includes output formats and notes" {
       #|  table, tsv, json (default: table)
       #|
       #|Notes:
-      #|  - Accepted fields: key,summary,status,assignee,type,priority,description,customfield_<id>
+      #|  - Accepted fields: key,summary,status,assignee,parent,type,priority,description,customfield_<id>
       #|  - Field aliases: type, issue_type, issuetype
       #|
       #|Examples:
@@ -368,6 +394,7 @@ test "format_issue_list_for_output: json wrapper is stable" {
         summary: "Fix bug",
         status: "Open",
         assignee: "Alice",
+        parent: "",
         issue_type: "Bug",
         priority: "High",
         description: "Line 1\nLine 2",
@@ -402,6 +429,7 @@ test "format_issue_detail_for_output: tsv is machine readable" {
     summary: "Fix bug",
     status: "Open",
     assignee: "Alice",
+    parent: "",
     issue_type: "Bug",
     priority: "High",
     description: "Line 1\nLine 2",

--- a/jira_cli_mbt.mbt
+++ b/jira_cli_mbt.mbt
@@ -66,17 +66,18 @@ async fn execute_command(
       summary~,
       issue_type~,
       description~,
+      parent~,
       custom_fields~,
       dry_run~
     ) => {
       let report = if dry_run {
         @api.preview_create_issue(
-          project, summary, issue_type, description, custom_fields,
+          project, summary, issue_type, description, parent, custom_fields,
         )
       } else {
         let config = @config.load_config()
         @api.create_issue(
-          config, project, summary, issue_type, description, custom_fields,
+          config, project, summary, issue_type, description, parent, custom_fields,
         )
       }
       @formatter.format_mutation_report_for_output(report, output_format)
@@ -88,13 +89,15 @@ async fn execute_command(
       priority~,
       issue_type~,
       labels~,
+      parent~,
       assignee~,
       custom_fields~,
       dry_run~
     ) => {
       let report = if dry_run {
         @api.preview_update_issue(
-          key, summary, description, priority, issue_type, labels, assignee, custom_fields,
+          key, summary, description, priority, issue_type, labels, parent, assignee,
+          custom_fields,
         )
       } else {
         let config = @config.load_config()
@@ -106,6 +109,7 @@ async fn execute_command(
           priority~,
           issue_type~,
           labels~,
+          parent~,
           assignee~,
           custom_fields~,
         )

--- a/parser/parser.mbt
+++ b/parser/parser.mbt
@@ -229,6 +229,7 @@ let create_flags : Map[String, String] = {
   "--summary": "summary",
   "--type": "issue_type",
   "--description": "description",
+  "--parent": "parent",
 }
 
 ///|
@@ -701,6 +702,7 @@ fn parse_create(args : ArrayView[String]) -> Result[@types.Command, String] {
             (Some(project), Some(summary)) => {
               let issue_type = flags.get("issue_type").unwrap_or("Task")
               let description = flags.get("description").unwrap_or("")
+              let parent = flags.get("parent").unwrap_or("")
               let custom_fields : Map[String, @types.CustomFieldInput] = {}
               for entry in set_entries {
                 custom_fields[entry.0] = entry.1
@@ -711,6 +713,7 @@ fn parse_create(args : ArrayView[String]) -> Result[@types.Command, String] {
                   summary~,
                   issue_type~,
                   description~,
+                  parent~,
                   custom_fields~,
                   dry_run~,
                 ),
@@ -718,7 +721,7 @@ fn parse_create(args : ArrayView[String]) -> Result[@types.Command, String] {
             }
             _ =>
               Err(
-                "Usage: create --project <key> --summary <text> [--type <type>] [--description <text>] [--set <field=value>]... [--set-json <json-object>] [--dry-run]",
+                "Usage: create --project <key> --summary <text> [--type <type>] [--description <text>] [--parent <key|id>] [--set <field=value>]... [--set-json <json-object>] [--dry-run]",
               )
           }
         Err(message) => Err(message)
@@ -769,11 +772,12 @@ let update_flags : Map[String, String] = {
   "--priority": "priority",
   "--type": "issue_type",
   "--labels": "labels",
+  "--parent": "parent",
   "--assignee": "assignee",
 }
 
 ///|
-let update_usage : String = "Usage: update <key> [--summary <text>] [--description <text>] [--priority <name>] [--type <name>] [--labels <label1,label2>] [--assignee <email>] [--set <field=value>]... [--set-json <json-object>] [--dry-run]"
+let update_usage : String = "Usage: update <key> [--summary <text>] [--description <text>] [--priority <name>] [--type <name>] [--labels <label1,label2>] [--parent <key|id>] [--assignee <email>] [--set <field=value>]... [--set-json <json-object>] [--dry-run]"
 
 ///|
 let get_field_flags : Map[String, String] = {
@@ -817,6 +821,7 @@ fn parse_update(args : ArrayView[String]) -> Result[@types.Command, String] {
           let priority = flags.get("priority").unwrap_or("")
           let issue_type = flags.get("issue_type").unwrap_or("")
           let labels = flags.get("labels").unwrap_or("")
+          let parent = flags.get("parent").unwrap_or("")
           let assignee = flags.get("assignee").unwrap_or("")
           let custom_fields : Map[String, @types.CustomFieldInput] = {}
           for entry in set_entries {
@@ -827,6 +832,7 @@ fn parse_update(args : ArrayView[String]) -> Result[@types.Command, String] {
             priority.length() > 0 ||
             issue_type.length() > 0 ||
             labels.length() > 0 ||
+            parent.length() > 0 ||
             assignee.length() > 0 ||
             custom_fields.length() > 0 else {
             return Err(
@@ -841,6 +847,7 @@ fn parse_update(args : ArrayView[String]) -> Result[@types.Command, String] {
               priority~,
               issue_type~,
               labels~,
+              parent~,
               assignee~,
               custom_fields~,
               dry_run~,

--- a/parser/parser_test.mbt
+++ b/parser/parser_test.mbt
@@ -166,6 +166,14 @@ test "parse_args: get issue with custom fields" {
 }
 
 ///|
+test "parse_args: get issue with parent field" {
+  inspect(
+    @parser.parse_args(["issue", "PROJ-123", "--fields", "parent"][:]),
+    content="Ok(GetIssue(key=\"PROJ-123\", fields=[Parent]))",
+  )
+}
+
+///|
 test "parse_args: issue without subcommand shows group help" {
   inspect(
     @parser.parse_args(["issue"][:]),
@@ -236,6 +244,7 @@ fn assert_create_issue_result(
   summary : String,
   issue_type : String,
   description : String,
+  parent : String,
   custom_fields : Map[String, String],
   dry_run : Bool,
 ) -> Unit raise {
@@ -246,6 +255,7 @@ fn assert_create_issue_result(
         summary=actual_summary,
         issue_type=actual_issue_type,
         description=actual_description,
+        parent=actual_parent,
         custom_fields=actual_custom_fields,
         dry_run=actual_dry_run
       )
@@ -254,6 +264,7 @@ fn assert_create_issue_result(
       assert_eq(actual_summary, summary)
       assert_eq(actual_issue_type, issue_type)
       assert_eq(actual_description, description)
+      assert_eq(actual_parent, parent)
       assert_eq(actual_dry_run, dry_run)
       assert_custom_field_display_values(actual_custom_fields, custom_fields)
     }
@@ -270,6 +281,7 @@ fn assert_update_issue_result(
   priority : String,
   issue_type : String,
   labels : String,
+  parent : String,
   assignee : String,
   custom_fields : Map[String, String],
   dry_run : Bool,
@@ -283,6 +295,7 @@ fn assert_update_issue_result(
         priority=actual_priority,
         issue_type=actual_issue_type,
         labels=actual_labels,
+        parent=actual_parent,
         assignee=actual_assignee,
         custom_fields=actual_custom_fields,
         dry_run=actual_dry_run
@@ -294,6 +307,7 @@ fn assert_update_issue_result(
       assert_eq(actual_priority, priority)
       assert_eq(actual_issue_type, issue_type)
       assert_eq(actual_labels, labels)
+      assert_eq(actual_parent, parent)
       assert_eq(actual_assignee, assignee)
       assert_eq(actual_dry_run, dry_run)
       assert_custom_field_display_values(actual_custom_fields, custom_fields)
@@ -312,6 +326,7 @@ test "parse_args: noun-verb issue create" {
     "Fix bug",
     "Task",
     "",
+    "",
     {},
     false,
   )
@@ -326,6 +341,7 @@ test "parse_args: legacy create issue" {
     "PROJ",
     "Fix bug",
     "Task",
+    "",
     "",
     {},
     false,
@@ -345,6 +361,7 @@ test "parse_args: create with type and description" {
     "Fix bug",
     "Bug",
     "Details",
+    "",
     {},
     false,
   )
@@ -361,6 +378,7 @@ test "parse_args: create with one --set flag" {
     "PROJ",
     "Fix bug",
     "Task",
+    "",
     "",
     { "customfield_12345": "High" },
     false,
@@ -380,6 +398,7 @@ test "parse_args: create with multiple --set flags" {
     "Fix bug",
     "Task",
     "",
+    "",
     { "customfield_12345": "High", "customfield_67890": "Team A" },
     false,
   )
@@ -396,6 +415,7 @@ test "parse_args: create --set value contains equals sign" {
     "PROJ",
     "Fix bug",
     "Task",
+    "",
     "",
     { "customfield_123": "a=b" },
     false,
@@ -439,6 +459,7 @@ test "parse_args: create --set duplicate key last wins" {
     "Fix bug",
     "Task",
     "",
+    "",
     { "customfield_123": "second" },
     false,
   )
@@ -481,6 +502,7 @@ test "parse_args: create --set multi-word value" {
     "Fix bug",
     "Task",
     "",
+    "",
     { "customfield_123": "hello world" },
     false,
   )
@@ -499,6 +521,7 @@ test "parse_args: create --set multi-word value followed by another flag" {
     "Fix bug",
     "Task",
     "",
+    "",
     { "customfield_123": "hello world", "customfield_456": "bar" },
     false,
   )
@@ -516,6 +539,7 @@ test "parse_args: create with --set-json supports multiple fields" {
     "PROJ",
     "Fix bug",
     "Task",
+    "",
     "",
     {
       "customfield_12345": "{\"id\":\"10401\"}",
@@ -564,6 +588,7 @@ test "parse_args: create with mixed --set and --set-json keeps last value" {
     "Fix bug",
     "Task",
     "",
+    "",
     { "customfield_123": "{\"id\":\"10401\"}", "customfield_456": "Backend" },
     false,
   )
@@ -581,8 +606,28 @@ test "parse_args: create with dry-run" {
     "Fix bug",
     "Task",
     "",
+    "",
     {},
     true,
+  )
+}
+
+///|
+test "parse_args: create with parent" {
+  assert_create_issue_result(
+    @parser.parse_args(
+      [
+        "issue", "create", "--project", "PROJ", "--summary", "Fix bug", "--parent",
+        "EPIC-123",
+      ][:],
+    ),
+    "PROJ",
+    "Fix bug",
+    "Task",
+    "",
+    "EPIC-123",
+    {},
+    false,
   )
 }
 
@@ -700,6 +745,7 @@ test "parse_args: update with summary" {
     "",
     "",
     "",
+    "",
     {},
     false,
   )
@@ -718,6 +764,7 @@ test "parse_args: update with priority and labels" {
     "",
     "bug,urgent",
     "",
+    "",
     {},
     false,
   )
@@ -730,6 +777,7 @@ test "parse_args: update with assignee only" {
       ["update", "TEST-1", "--assignee", "user@example.com"][:],
     ),
     "TEST-1",
+    "",
     "",
     "",
     "",
@@ -756,6 +804,7 @@ test "parse_args: update with description and custom field" {
     "",
     "",
     "",
+    "",
     { "customfield_123": "value" },
     false,
   )
@@ -772,6 +821,7 @@ test "parse_args: update with type only" {
     "Bug",
     "",
     "",
+    "",
     {},
     false,
   )
@@ -783,8 +833,8 @@ test "parse_args: update with all flags" {
     @parser.parse_args(
       [
         "update", "TEST-1", "--summary", "title", "--description", "desc", "--priority",
-        "High", "--type", "Bug", "--labels", "bug", "--assignee", "a@b.com", "--set",
-        "customfield_123=val",
+        "High", "--type", "Bug", "--labels", "bug", "--parent", "EPIC-123", "--assignee",
+        "a@b.com", "--set", "customfield_123=val",
       ][:],
     ),
     "TEST-1",
@@ -793,6 +843,7 @@ test "parse_args: update with all flags" {
     "High",
     "Bug",
     "bug",
+    "EPIC-123",
     "a@b.com",
     { "customfield_123": "val" },
     false,
@@ -808,6 +859,7 @@ test "parse_args: update with --set-json supports multiple fields" {
       ][:],
     ),
     "TEST-1",
+    "",
     "",
     "",
     "",
@@ -835,8 +887,26 @@ test "parse_args: update with dry-run" {
     "",
     "",
     "",
+    "",
     {},
     true,
+  )
+}
+
+///|
+test "parse_args: update with parent only" {
+  assert_update_issue_result(
+    @parser.parse_args(["issue", "update", "TEST-1", "--parent", "EPIC-123"][:]),
+    "TEST-1",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "EPIC-123",
+    "",
+    {},
+    false,
   )
 }
 

--- a/types/command_specs.mbt
+++ b/types/command_specs.mbt
@@ -36,7 +36,7 @@ fn global_output_formats() -> Array[OutputFormat] {
 
 ///|
 fn issues_field_note() -> String {
-  "Accepted fields: key,summary,status,assignee,type,priority,description,customfield_<id>"
+  "Accepted fields: key,summary,status,assignee,parent,type,priority,description,customfield_<id>"
 }
 
 ///|
@@ -288,7 +288,7 @@ fn create_command_spec() -> CommandSpec {
   {
     name: "issue create",
     summary: "Create a new issue",
-    usage: "issue create --project <key> --summary <text> [--type <type>] [--description <text>] [--set <field=value>]... [--set-json <json-object>] [--dry-run] [--format <table|tsv|json>]",
+    usage: "issue create --project <key> --summary <text> [--type <type>] [--description <text>] [--parent <key|id>] [--set <field=value>]... [--set-json <json-object>] [--dry-run] [--format <table|tsv|json>]",
     aliases: ["create"],
     positionals: [],
     flags: [
@@ -329,6 +329,15 @@ fn create_command_spec() -> CommandSpec {
         aliases: [],
       },
       {
+        name: "--parent",
+        value_name: "key|id",
+        description: "Parent issue key or numeric id",
+        required: false,
+        repeatable: false,
+        default_value: None,
+        aliases: [],
+      },
+      {
         name: "--set",
         value_name: "customfield_<id>=<value>",
         description: "Set a custom field value",
@@ -358,13 +367,14 @@ fn create_command_spec() -> CommandSpec {
     ],
     output_formats: global_output_formats(),
     notes: [
-      "--set only accepts customfield_* keys and remains a convenience shortcut",
+      "Use --parent for Jira's standard parent field", "--set only accepts customfield_* keys and remains a convenience shortcut",
       "--set-json accepts a JSON object mapping customfield_* keys to JSON values",
       "Prefer --set-json for explicit typed values such as {\"id\":\"10401\"}", "If a --set value is all digits, the CLI preserves the legacy convenience behavior and sends it as an option id object",
       "--dry-run returns a structured preview and does not require Jira config",
     ],
     examples: [
       "jira-cli issue create --project APP --summary \"Fix login bug\" --type Bug",
+      "jira-cli issue create --project APP --summary \"Follow up rollout\" --parent EPIC-123",
       "jira-cli issue create --project APP --summary \"Provision access\" --set customfield_10001=10401",
       "jira-cli issue create --project APP --summary \"Provision access\" --set-json '{\"customfield_10001\":{\"id\":\"10401\"},\"customfield_10002\":\"Platform Team\"}'",
       "jira-cli issue create --project APP --summary \"Provision access\" --dry-run --format json",
@@ -377,7 +387,7 @@ fn update_command_spec() -> CommandSpec {
   {
     name: "issue update",
     summary: "Update an existing issue",
-    usage: "issue update <key> [--summary <text>] [--description <text>] [--priority <name>] [--type <name>] [--labels <label1,label2>] [--assignee <email>] [--set <field=value>]... [--set-json <json-object>] [--dry-run] [--format <table|tsv|json>]",
+    usage: "issue update <key> [--summary <text>] [--description <text>] [--priority <name>] [--type <name>] [--labels <label1,label2>] [--parent <key|id>] [--assignee <email>] [--set <field=value>]... [--set-json <json-object>] [--dry-run] [--format <table|tsv|json>]",
     aliases: ["update"],
     positionals: [
       { name: "key", description: "Issue key to update", required: true },
@@ -429,6 +439,15 @@ fn update_command_spec() -> CommandSpec {
         aliases: [],
       },
       {
+        name: "--parent",
+        value_name: "key|id",
+        description: "Parent issue key or numeric id",
+        required: false,
+        repeatable: false,
+        default_value: None,
+        aliases: [],
+      },
+      {
         name: "--assignee",
         value_name: "email",
         description: "Assignee email address",
@@ -468,12 +487,13 @@ fn update_command_spec() -> CommandSpec {
     output_formats: global_output_formats(),
     notes: [
       "At least one update field is required", "update may partially succeed if assignee changes fail after field updates",
-      "--set only accepts customfield_* keys and remains a convenience shortcut",
+      "Use --parent for Jira's standard parent field", "--set only accepts customfield_* keys and remains a convenience shortcut",
       "--set-json accepts a JSON object mapping customfield_* keys to JSON values",
       "Prefer --set-json for explicit typed values such as {\"id\":\"10401\"}", "--dry-run returns a structured preview and does not require Jira config",
     ],
     examples: [
-      "jira-cli issue update APP-123 --priority High --labels backend,urgent", "jira-cli issue update APP-123 --summary \"Refine rollout plan\" --set customfield_10001=10401",
+      "jira-cli issue update APP-123 --priority High --labels backend,urgent", "jira-cli issue update APP-123 --parent EPIC-123",
+      "jira-cli issue update APP-123 --summary \"Refine rollout plan\" --set customfield_10001=10401",
       "jira-cli issue update APP-123 --set-json '{\"customfield_10001\":{\"id\":\"10401\"},\"customfield_10002\":[\"Backend\",\"Urgent\"]}'",
       "jira-cli issue update APP-123 --summary \"Refine rollout plan\" --assignee user@example.com --dry-run --format json",
     ],

--- a/types/pkg.generated.mbti
+++ b/types/pkg.generated.mbti
@@ -58,8 +58,8 @@ pub(all) enum Command {
   Config(base_url~ : String, email~ : String, api_token~ : String, api_token_stdin~ : Bool)
   ListIssues(jql~ : String, fields~ : Array[IssueField], page_request~ : PageRequest)
   GetIssue(key~ : String, fields~ : Array[IssueField])
-  CreateIssue(project~ : String, summary~ : String, issue_type~ : String, description~ : String, custom_fields~ : Map[String, CustomFieldInput], dry_run~ : Bool)
-  UpdateIssue(key~ : String, summary~ : String, description~ : String, priority~ : String, issue_type~ : String, labels~ : String, assignee~ : String, custom_fields~ : Map[String, CustomFieldInput], dry_run~ : Bool)
+  CreateIssue(project~ : String, summary~ : String, issue_type~ : String, description~ : String, parent~ : String, custom_fields~ : Map[String, CustomFieldInput], dry_run~ : Bool)
+  UpdateIssue(key~ : String, summary~ : String, description~ : String, priority~ : String, issue_type~ : String, labels~ : String, parent~ : String, assignee~ : String, custom_fields~ : Map[String, CustomFieldInput], dry_run~ : Bool)
   Transition(key~ : String, status~ : String)
   Comment(key~ : String, text~ : String)
   Assign(key~ : String, email~ : String)
@@ -148,6 +148,7 @@ pub(all) enum IssueField {
   Summary
   Status
   Assignee
+  Parent
   IssueType
   Priority
   Description
@@ -201,6 +202,7 @@ pub(all) struct JiraIssue {
   summary : String
   status : String
   assignee : String
+  parent : String
   issue_type : String
   priority : String
   description : String

--- a/types/types.mbt
+++ b/types/types.mbt
@@ -11,6 +11,7 @@ pub(all) enum IssueField {
   Summary
   Status
   Assignee
+  Parent
   IssueType
   Priority
   Description
@@ -86,6 +87,7 @@ pub fn parse_issue_field(name : String) -> Result[IssueField, String] {
     "summary" => Ok(Summary)
     "status" => Ok(Status)
     "assignee" => Ok(Assignee)
+    "parent" => Ok(Parent)
     "type" | "issue_type" | "issuetype" => Ok(IssueType)
     "priority" => Ok(Priority)
     "description" => Ok(Description)
@@ -102,6 +104,7 @@ pub fn IssueField::api_name(self : IssueField) -> String {
     Summary => "summary"
     Status => "status"
     Assignee => "assignee"
+    Parent => "parent"
     IssueType => "issuetype"
     Priority => "priority"
     Description => "description"
@@ -116,6 +119,7 @@ pub fn IssueField::list_header(self : IssueField) -> String {
     Summary => "SUMMARY"
     Status => "STATUS"
     Assignee => "ASSIGNEE"
+    Parent => "PARENT"
     IssueType => "TYPE"
     Priority => "PRIORITY"
     Description => "DESCRIPTION"
@@ -130,6 +134,7 @@ pub fn IssueField::detail_label(self : IssueField) -> String {
     Summary => "Summary"
     Status => "Status"
     Assignee => "Assignee"
+    Parent => "Parent"
     IssueType => "Type"
     Priority => "Priority"
     Description => "Description"
@@ -144,6 +149,7 @@ pub fn IssueField::table_width(self : IssueField) -> Int {
     Summary => 40
     Status => 15
     Assignee => 20
+    Parent => 14
     IssueType => 12
     Priority => 10
     Description => 40
@@ -157,6 +163,7 @@ pub(all) struct JiraIssue {
   summary : String
   status : String
   assignee : String
+  parent : String
   issue_type : String
   priority : String
   description : String
@@ -170,6 +177,7 @@ pub fn JiraIssue::field_value(self : JiraIssue, field : IssueField) -> String {
     Summary => self.summary
     Status => self.status
     Assignee => self.assignee
+    Parent => self.parent
     IssueType => self.issue_type
     Priority => self.priority
     Description => self.description
@@ -225,6 +233,7 @@ pub(all) enum Command {
     summary~ : String,
     issue_type~ : String,
     description~ : String,
+    parent~ : String,
     custom_fields~ : Map[String, CustomFieldInput],
     dry_run~ : Bool
   )
@@ -235,6 +244,7 @@ pub(all) enum Command {
     priority~ : String,
     issue_type~ : String,
     labels~ : String,
+    parent~ : String,
     assignee~ : String,
     custom_fields~ : Map[String, CustomFieldInput],
     dry_run~ : Bool

--- a/types/types_test.mbt
+++ b/types/types_test.mbt
@@ -2,6 +2,7 @@
 test "parse_issue_field supports aliases" {
   inspect(@types.parse_issue_field("type"), content="Ok(IssueType)")
   inspect(@types.parse_issue_field("issuetype"), content="Ok(IssueType)")
+  inspect(@types.parse_issue_field("parent"), content="Ok(Parent)")
   inspect(
     @types.parse_issue_field("customfield_12345"),
     content="Ok(Custom(\"customfield_12345\"))",
@@ -48,12 +49,14 @@ test "jira issue field_value reads requested field" {
     summary: "Fix bug",
     status: "Open",
     assignee: "Alice",
+    parent: "EPIC-1",
     issue_type: "Bug",
     priority: "High",
     description: "Details",
     custom_fields: { "customfield_12345": "Platform Team" },
   }
   assert_eq(issue.field_value(@types.Assignee), "Alice")
+  assert_eq(issue.field_value(@types.Parent), "EPIC-1")
   assert_eq(issue.field_value(@types.Description), "Details")
   assert_eq(
     issue.field_value(@types.Custom("customfield_12345")),
@@ -115,6 +118,7 @@ test "command specs resolve canonical names and aliases" {
     "table,tsv,json",
   )
   assert_true(create_spec.flags.any(fn(flag) { flag.name == "--dry-run" }))
+  assert_true(create_spec.flags.any(fn(flag) { flag.name == "--parent" }))
   assert_true(create_spec.flags.any(fn(flag) { flag.name == "--set-json" }))
 
   let issue_group_spec = @types.require_command_spec("issue").unwrap()
@@ -126,5 +130,6 @@ test "command specs resolve canonical names and aliases" {
     "table,tsv,json",
   )
   assert_true(update_spec.flags.any(fn(flag) { flag.name == "--dry-run" }))
+  assert_true(update_spec.flags.any(fn(flag) { flag.name == "--parent" }))
   assert_true(update_spec.flags.any(fn(flag) { flag.name == "--set-json" }))
 }


### PR DESCRIPTION
## Summary
- add `--parent` to `issue create` and `issue update`
- send Jira's standard `fields.parent` payload and include it in dry-run reports
- add readable `parent` field support to `issue get` / `issue list --fields parent`
- update docs, help text, tests, and generated interfaces

## Validation
- `moon info --target js`
- `moon fmt`
- `moon test --target js`

Closes #39


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--parent <key|id>` option to `jira-cli issue create` and `jira-cli issue update` commands, enabling you to establish parent-child issue relationships. The parent can be specified using either an issue key or numeric ID.
  * Extended available fields to include `parent` for use with field selection options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->