### PR TITLE
feat: sprint コマンド (list/add/remove) を追加

### DIFF
--- a/api/api.mbt
+++ b/api/api.mbt
@@ -665,19 +665,34 @@ fn parse_sprint(s : @core.Any) -> @types.JiraSprint {
 ///|
 // List sprints on a board.
 // state: comma-separated list of "active", "future", "closed". Empty = all.
+//
+// The /rest/agile/1.0/board/{boardId}/sprint endpoint is paginated (default
+// maxResults = 50), so we follow `isLast` and `startAt` until exhausted to
+// surface every sprint regardless of board size.
 pub async fn list_board_sprints(
   config : @types.JiraConfig,
   board_id : String,
   state : String,
 ) -> Array[@types.JiraSprint] {
-  let path = if state.length() > 0 {
-    "/rest/agile/1.0/board/\{board_id}/sprint?state=\{state}"
-  } else {
-    "/rest/agile/1.0/board/\{board_id}/sprint"
+  let items : Array[@types.JiraSprint] = []
+  let mut start_at = 0
+  let mut is_last = false
+  while not(is_last) {
+    let state_param = if state.length() > 0 { "&state=\{state}" } else { "" }
+    let path =
+      "/rest/agile/1.0/board/\{board_id}/sprint?startAt=\{start_at}\{state_param}"
+    let data = api_request(config, "GET", path)
+    let values = @core.array_from(data._get("values"))
+    if values.is_empty() {
+      break
+    }
+    for v in values {
+      items.push(parse_sprint(v))
+    }
+    is_last = get_string(data, "isLast") == "true"
+    start_at = start_at + values.length()
   }
-  let data = api_request(config, "GET", path)
-  let values = @core.array_from(data._get("values"))
-  values.map(parse_sprint)
+  items
 }
 
 ///|

--- a/api/api.mbt
+++ b/api/api.mbt
@@ -654,6 +654,66 @@ pub async fn add_comment(
 }
 
 ///|
+fn parse_sprint(s : @core.Any) -> @types.JiraSprint {
+  {
+    id: get_string(s, "id"),
+    state: get_string(s, "state"),
+    name: get_string(s, "name"),
+  }
+}
+
+///|
+// List sprints on a board.
+// state: comma-separated list of "active", "future", "closed". Empty = all.
+pub async fn list_board_sprints(
+  config : @types.JiraConfig,
+  board_id : String,
+  state : String,
+) -> Array[@types.JiraSprint] {
+  let path = if state.length() > 0 {
+    "/rest/agile/1.0/board/\{board_id}/sprint?state=\{state}"
+  } else {
+    "/rest/agile/1.0/board/\{board_id}/sprint"
+  }
+  let data = api_request(config, "GET", path)
+  let values = @core.array_from(data._get("values"))
+  values.map(parse_sprint)
+}
+
+///|
+// Move an issue into the given sprint (by sprint id).
+pub async fn add_issue_to_sprint(
+  config : @types.JiraConfig,
+  key : String,
+  sprint_id : String,
+) -> Unit {
+  let issues : Array[@core.Any] = [@core.any(key)]
+  let body = @core.from_entries([("issues", @core.any(issues))])
+  let _ = api_request(
+    config,
+    "POST",
+    "/rest/agile/1.0/sprint/\{sprint_id}/issue",
+    body~,
+  )
+}
+
+///|
+// Move an issue back to the backlog (out of any sprint).
+pub async fn remove_issue_from_sprint(
+  config : @types.JiraConfig,
+  key : String,
+) -> Unit {
+  let issues : Array[@core.Any] = [@core.any(key)]
+  let body = @core.from_entries([("issues", @core.any(issues))])
+  let _ = api_request(
+    config,
+    "POST",
+    "/rest/agile/1.0/backlog/issue",
+    body~,
+  )
+}
+
+///|
 async fn search_users(config : @types.JiraConfig, email : String) -> @core.Any {
   let encoded = encode_uri_component(email)
   api_request(config, "GET", "/rest/api/3/user/search?query=\{encoded}")

--- a/formatter/formatter.mbt
+++ b/formatter/formatter.mbt
@@ -453,6 +453,57 @@ pub fn format_projects_for_output(
 }
 
 ///|
+pub fn format_sprints(sprints : Array[@types.JiraSprint]) -> String {
+  if sprints.is_empty() {
+    return "No sprints found."
+  }
+  let headers = ["ID", "STATE", "NAME"]
+  let widths = [12, 11, 30]
+  let rows = sprints.map(fn(s) { [s.id, s.state, truncate(s.name, 30)] })
+  format_table(headers, rows, widths)
+}
+
+///|
+fn format_sprints_tsv(sprints : Array[@types.JiraSprint]) -> String {
+  let rows = sprints.map(fn(s) { [s.id, s.state, s.name] })
+  [format_tsv_row(["id", "state", "name"]), ..rows.map(format_tsv_row)].join(
+    "\n",
+  )
+}
+
+///|
+fn format_sprints_json(sprints : Array[@types.JiraSprint]) -> String {
+  json_object([
+    ("schema_version", json_string("v1")),
+    ("kind", json_string("sprints")),
+    (
+      "items",
+      json_array(
+        sprints.map(fn(s) {
+          json_object([
+            ("id", json_string(s.id)),
+            ("state", json_string(s.state)),
+            ("name", json_string(s.name)),
+          ])
+        }),
+      ),
+    ),
+  ])
+}
+
+///|
+pub fn format_sprints_for_output(
+  sprints : Array[@types.JiraSprint],
+  output_format : @types.OutputFormat,
+) -> String {
+  match output_format {
+    @types.Table => format_sprints(sprints)
+    @types.Tsv => format_sprints_tsv(sprints)
+    @types.Json => format_sprints_json(sprints)
+  }
+}
+
+///|
 pub fn format_fields(fields : Array[@types.JiraField]) -> String {
   if fields.is_empty() {
     return "No custom fields found."

--- a/jira_cli_mbt.mbt
+++ b/jira_cli_mbt.mbt
@@ -167,6 +167,23 @@ async fn execute_command(
         )
       }
     }
+    @types.SprintList(board_id~, state~) => {
+      let config = @config.load_config()
+      @formatter.format_sprints_for_output(
+        @api.list_board_sprints(config, board_id, state),
+        output_format,
+      )
+    }
+    @types.SprintAdd(key~, sprint_id~) => {
+      let config = @config.load_config()
+      @api.add_issue_to_sprint(config, key, sprint_id)
+      "Issue \{key} moved into sprint \{sprint_id}"
+    }
+    @types.SprintRemove(key~) => {
+      let config = @config.load_config()
+      @api.remove_issue_from_sprint(config, key)
+      "Issue \{key} removed from sprint (returned to backlog)"
+    }
   }
 }
 

--- a/parser/parser.mbt
+++ b/parser/parser.mbt
@@ -27,10 +27,21 @@ pub fn parse_args(args : ArrayView[String]) -> Result[@types.Command, String] {
     ["fields", field_id, .. rest] if not(field_id.has_prefix("--")) =>
       parse_get_field(field_id, rest)
     ["fields", .. rest] => parse_field_list(rest)
-    ["sprint", "list", .. rest] => parse_sprint_list(rest)
-    ["sprint", "add", .. rest] => parse_sprint_add(rest)
-    ["sprint", "remove", .. rest] => parse_sprint_remove(rest)
+    ["sprint", .. rest] => parse_sprint_group(rest)
     [cmd, ..] => Err("Unknown command: \{cmd}")
+  }
+}
+
+///|
+fn parse_sprint_group(
+  args : ArrayView[String],
+) -> Result[@types.Command, String] {
+  match args {
+    [] => Ok(@types.Help(command_name="sprint"))
+    ["list", .. rest] => parse_sprint_list(rest)
+    ["add", .. rest] => parse_sprint_add(rest)
+    ["remove", .. rest] => parse_sprint_remove(rest)
+    [subcommand, ..] => Err("Unknown sprint subcommand: \{subcommand}")
   }
 }
 
@@ -786,9 +797,12 @@ fn parse_sprint_list(args : ArrayView[String]) -> Result[@types.Command, String]
     Ok(flags) =>
       match flags.get("board_id") {
         Some(board_id) => {
+          // Default = empty (all states). `--state all` is a no-op alias for
+          // explicit "give me everything". Any other value is forwarded
+          // verbatim to the JIRA Agile API.
           let state = match flags.get("state") {
-            Some(s) => s
-            None => "active"
+            Some(s) => if s == "all" { "" } else { s }
+            None => ""
           }
           Ok(@types.SprintList(board_id~, state~))
         }

--- a/parser/parser.mbt
+++ b/parser/parser.mbt
@@ -27,6 +27,9 @@ pub fn parse_args(args : ArrayView[String]) -> Result[@types.Command, String] {
     ["fields", field_id, .. rest] if not(field_id.has_prefix("--")) =>
       parse_get_field(field_id, rest)
     ["fields", .. rest] => parse_field_list(rest)
+    ["sprint", "list", .. rest] => parse_sprint_list(rest)
+    ["sprint", "add", .. rest] => parse_sprint_add(rest)
+    ["sprint", "remove", .. rest] => parse_sprint_remove(rest)
     [cmd, ..] => Err("Unknown command: \{cmd}")
   }
 }
@@ -757,6 +760,63 @@ fn parse_assign(args : ArrayView[String]) -> Result[@types.Command, String] {
       match (flags.get("key"), flags.get("email")) {
         (Some(key), Some(email)) => Ok(@types.Assign(key~, email~))
         _ => Err("Usage: assign --key <key> --email <email>")
+      }
+    Err(message) => Err(message)
+  }
+}
+
+///|
+let sprint_list_flags : Map[String, String] = {
+  "--board-id": "board_id",
+  "--state": "state",
+}
+
+///|
+let sprint_add_flags : Map[String, String] = {
+  "--key": "key",
+  "--sprint-id": "sprint_id",
+}
+
+///|
+let sprint_remove_flags : Map[String, String] = { "--key": "key" }
+
+///|
+fn parse_sprint_list(args : ArrayView[String]) -> Result[@types.Command, String] {
+  match parse_flags(args, sprint_list_flags, {}) {
+    Ok(flags) =>
+      match flags.get("board_id") {
+        Some(board_id) => {
+          let state = match flags.get("state") {
+            Some(s) => s
+            None => "active"
+          }
+          Ok(@types.SprintList(board_id~, state~))
+        }
+        None => Err("Usage: sprint list --board-id <id> [--state <state>]")
+      }
+    Err(message) => Err(message)
+  }
+}
+
+///|
+fn parse_sprint_add(args : ArrayView[String]) -> Result[@types.Command, String] {
+  match parse_flags(args, sprint_add_flags, {}) {
+    Ok(flags) =>
+      match (flags.get("key"), flags.get("sprint_id")) {
+        (Some(key), Some(sprint_id)) => Ok(@types.SprintAdd(key~, sprint_id~))
+        _ => Err("Usage: sprint add --key <key> --sprint-id <sprint id>")
+      }
+    Err(message) => Err(message)
+  }
+}
+
+///|
+fn parse_sprint_remove(args : ArrayView[String]) -> Result[@types.Command, String] {
+  match parse_flags(args, sprint_remove_flags, {}) {
+    Ok(flags) =>
+      match flags.get("key") {
+        Some(key) => Ok(@types.SprintRemove(key~))
+        None => Err("Usage: sprint remove --key <key>")
       }
     Err(message) => Err(message)
   }

--- a/types/command_specs.mbt
+++ b/types/command_specs.mbt
@@ -146,6 +146,125 @@ fn field_group_spec() -> CommandSpec {
 }
 
 ///|
+fn sprint_group_spec() -> CommandSpec {
+  {
+    name: "sprint",
+    summary: "Sprint operations (Jira Software / Agile API)",
+    usage: "sprint <subcommand> [options]",
+    aliases: [],
+    positionals: [
+      { name: "subcommand", description: "One of list, add, remove", required: true },
+    ],
+    flags: [],
+    output_formats: [],
+    notes: ["Canonical subcommands: list, add, remove"],
+    examples: [
+      "jira-cli sprint list --board-id 3 --state active",
+      "jira-cli sprint add --key APP-123 --sprint-id 42",
+      "jira-cli sprint remove --key APP-123",
+    ],
+  }
+}
+
+///|
+fn sprint_list_command_spec() -> CommandSpec {
+  {
+    name: "sprint list",
+    summary: "List sprints on a board (Agile API)",
+    usage: "sprint list --board-id <id> [--state <state>]",
+    aliases: [],
+    positionals: [],
+    flags: [
+      {
+        name: "--board-id",
+        value_name: "id",
+        description: "Board id whose sprints to list",
+        required: true,
+        repeatable: false,
+        default_value: None,
+        aliases: [],
+      },
+      {
+        name: "--state",
+        value_name: "state",
+        description: "active | future | closed (comma-separated). 'all' or omitted = every state",
+        required: false,
+        repeatable: false,
+        default_value: Some(""),
+        aliases: [],
+      },
+    ],
+    output_formats: global_output_formats(),
+    notes: [
+      "Paginates through every sprint on the board until isLast is true.",
+    ],
+    examples: [
+      "jira-cli sprint list --board-id 3 --state active",
+      "jira-cli sprint list --board-id 3 --format json",
+    ],
+  }
+}
+
+///|
+fn sprint_add_command_spec() -> CommandSpec {
+  {
+    name: "sprint add",
+    summary: "Move an issue into a sprint (Agile API)",
+    usage: "sprint add --key <key> --sprint-id <sprint id>",
+    aliases: [],
+    positionals: [],
+    flags: [
+      {
+        name: "--key",
+        value_name: "key",
+        description: "Issue key to move",
+        required: true,
+        repeatable: false,
+        default_value: None,
+        aliases: [],
+      },
+      {
+        name: "--sprint-id",
+        value_name: "sprint id",
+        description: "Target sprint id (numeric)",
+        required: true,
+        repeatable: false,
+        default_value: None,
+        aliases: [],
+      },
+    ],
+    output_formats: [],
+    notes: ["Use `sprint list` to discover the active sprint id for a board."],
+    examples: ["jira-cli sprint add --key APP-123 --sprint-id 42"],
+  }
+}
+
+///|
+fn sprint_remove_command_spec() -> CommandSpec {
+  {
+    name: "sprint remove",
+    summary: "Move an issue back to the backlog (Agile API)",
+    usage: "sprint remove --key <key>",
+    aliases: [],
+    positionals: [],
+    flags: [
+      {
+        name: "--key",
+        value_name: "key",
+        description: "Issue key to remove from its sprint",
+        required: true,
+        repeatable: false,
+        default_value: None,
+        aliases: [],
+      },
+    ],
+    output_formats: [],
+    notes: [],
+    examples: ["jira-cli sprint remove --key APP-123"],
+  }
+}
+
+///|
 fn config_command_spec() -> CommandSpec {
   {
     name: "config",
@@ -771,6 +890,10 @@ pub fn command_specs() -> Array[CommandSpec] {
     field_group_spec(),
     field_list_command_spec(),
     field_get_command_spec(),
+    sprint_group_spec(),
+    sprint_list_command_spec(),
+    sprint_add_command_spec(),
+    sprint_remove_command_spec(),
     help_command_spec(),
     describe_command_spec(),
   ]

--- a/types/types.mbt
+++ b/types/types.mbt
@@ -185,6 +185,13 @@ pub(all) struct JiraProject {
 } derive(Show)
 
 ///|
+pub(all) struct JiraSprint {
+  id : String
+  state : String
+  name : String
+} derive(Show)
+
+///|
 pub(all) struct JiraIssuePage {
   items : Array[JiraIssue]
   page : PageInfo
@@ -246,6 +253,13 @@ pub(all) enum Command {
   ListProjects(page_request~ : PageRequest)
   ListFields(page_request~ : PageRequest)
   GetField(field_id~ : String, project~ : String, issue_type~ : String)
+  // Sprint operations on the JIRA Agile API.
+  // SprintList lists sprints on a board (default state=active).
+  // SprintAdd moves an issue into the given sprint by id.
+  // SprintRemove moves an issue back to the backlog (out of any sprint).
+  SprintList(board_id~ : String, state~ : String)
+  SprintAdd(key~ : String, sprint_id~ : String)
+  SprintRemove(key~ : String)
   Help(command_name~ : String)
   Describe(command_name~ : String)
 } derive(Show)


### PR DESCRIPTION
## 概要

JIRA Agile REST API を叩くサブコマンドを 3 つ追加し、ターミナルから抜けずにスプリントへの追加・除外と active sprint の確認ができるようにします。

```sh
jira-cli sprint list   --board-id <id> [--state <state>]   # 既定値: active
jira-cli sprint add    --key <key> --sprint-id <sprint id>
jira-cli sprint remove --key <key>                          # backlog に戻す
```

実装は既存の `transition` コマンドと同じ仕組み（`JiraConfig` + `api_request`）を流用しており、parser は `transition` / `assign` と同じフラグスタイル、`sprint list` の出力は既存の `formatter` モジュールに `format_sprints_for_output` を追加して `table` / `tsv` / `json` を全部サポートしています。**ルートパッケージへの新規依存は追加していません。**

## 動機

スプリント運用の中で「issue を active sprint に追加 / 外す」が頻繁に発生します（スタンドアップ中、優先度変更、Obsidian プラグイン側の状態を JIRA に反映するなど）。これまでは raw `curl` で Agile API を直接叩く必要があったので、CLI として最低限の 3 コマンドをカバーします。

## API 対応

| サブコマンド | HTTP | パス |
|---|---|---|
| `sprint list` | `GET` | `/rest/agile/1.0/board/{boardId}/sprint?state=<state>` |
| `sprint add` | `POST` | `/rest/agile/1.0/sprint/{sprintId}/issue` body `{"issues": ["KEY"]}` |
| `sprint remove` | `POST` | `/rest/agile/1.0/backlog/issue` body `{"issues": ["KEY"]}` |

## 変更ファイル

- `types/types.mbt` — `Command` enum に `SprintList` / `SprintAdd` / `SprintRemove` の 3 バリアントを追加、`JiraSprint` struct も追加
- `parser/parser.mbt` — トップレベルのルーティング (`["sprint", "list", ..]` 等) とサブコマンドごとの flag parser
- `api/api.mbt` — `list_board_sprints` / `add_issue_to_sprint` / `remove_issue_from_sprint` と `parse_sprint` helper
- `formatter/formatter.mbt` — `format_sprints` / `format_sprints_tsv` / `format_sprints_json` / `format_sprints_for_output`
- `jira_cli_mbt.mbt` — `execute_command` に 3 バリアントの分岐を追加（既存の `@formatter.format_*_for_output` 委譲パターンに揃えた）

合計 +202 行、既存の挙動には変更なし、新規依存もなしです。

## 出力サンプル

```
$ jira-cli sprint list --board-id 3 --state active
ID            STATE        NAME
------------  -----------  ------------------------------
3548          active       ASSIGN スプリント 156

$ jira-cli --format json sprint list --board-id 3 --state active
{"schema_version":"v1","kind":"sprints","items":[{"id":"3548","state":"active","name":"ASSIGN スプリント 156"}]}

$ jira-cli sprint add --key AJ-44656 --sprint-id 3548
Issue AJ-44656 moved into sprint 3548

$ jira-cli sprint remove --key AJ-44656
Issue AJ-44656 removed from sprint (returned to backlog)
```

## 動作確認

実際の JIRA Cloud に対して end-to-end で確認済みです（`sprint list` で active sprint を取得、`sprint add` / `sprint remove` で issue がスプリントとバックログを往復し、JIRA の board UI 上にも反映される）。`--format json` の出力も既存パターンと同じ schema (`schema_version` / `kind` / `items`) を踏襲しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Sprint management: List sprints for a board with optional state filtering to organize work across sprints.
  * Add issues to sprints or remove them back to the backlog for flexible sprint planning.
  * Sprint data displayed in table, TSV, or JSON formats based on your preference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->